### PR TITLE
Qt moved out of vcpkg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,10 @@ jobs:
             build-type: Release
 
     steps:
-      - name: Install Dependencies (Linux)
-        run: sudo apt install gperf libfontconfig1-dev libfreetype6-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-xinerama0-dev libxcb-render-util0-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-dev libxft-dev libxext-dev libgl1-mesa-dev libglu1-mesa-dev libgles2-mesa-dev libdbus-1-dev libxi-dev libxtst-dev autoconf-archive linux-headers-$(uname -r)
-        if: matrix.os == 'ubuntu-latest'
-      - name: Install Dependencies (macOS)
-        run: brew install autoconf automake libtool autoconf-archive
-        if: matrix.os == 'macos-latest'
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          modules: 'qtwebengine'
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -10,6 +10,48 @@ In addition to the forthcoming text-to-speech engine, QuickTurns also offers oth
 
 QuickTurns is a highly versatile ebook reader that offers exceptional performance and features. Its promise of a special text-to-speech engine in the future makes it an excellent option for people who want to switch between reading and listening to their favorite books.
 
+## Setting up QT Environment
+
+Windows/Mac
+
+1. Download the QT installer for Windows from the [QT online-installers](https://www.qt.io/download). For offline installer [QT offline-installers](https://www.qt.io/offline-installers)
+2. Run the installer and follow the instructions to install QT on your computer. Make sure to select the components you want to install.
+3. Make sure Qt location is added to PATH environment variables.
+
+Linux
+
+Install the QT development tools using your distribution's package manager.
+
+- Ubuntu
+    ```
+    sudo apt-get update
+    sudo apt-get install build-essential qt5-qmake qtbase5-dev
+    ```
+- Fedora
+    ```
+    sudo dnf update
+    sudo dnf groupinstall "Development Tools"
+    sudo dnf install qt5-devel
+    ```
+- CentOS/RHEL
+    ```
+    sudo yum update
+    sudo yum groupinstall "Development Tools"
+    sudo yum install qt5-devel
+    ```
+- Arch Linux
+    ```
+    sudo pacman -Syu
+    sudo pacman -S base-devel
+    sudo pacman -S qt5-base
+    ```
+- openSUSE
+    ```
+    sudo zypper update
+    sudo zypper install -t pattern devel_basis
+    sudo zypper install libqt5-qtbase-devel
+    ```
+
 ## Installation
 - `git clone --recurse-submodules git@github.com:tmargary/QuickTurns.git`
 - `cd QuickTurns`

--- a/README.md
+++ b/README.md
@@ -23,33 +23,45 @@ Linux
 Install the QT development tools using your distribution's package manager.
 
 - Ubuntu
+
     ```
-    sudo apt-get update
-    sudo apt-get install build-essential qt5-qmake qtbase5-dev
+    sudo apt update
+    sudo apt upgrade
+    sudo apt install qt6-default libqt6webenginecore-dev libqt6webenginewidgets-dev
+    qmake -v
     ```
-- Fedora
-    ```
-    sudo dnf update
-    sudo dnf groupinstall "Development Tools"
-    sudo dnf install qt5-devel
-    ```
-- CentOS/RHEL
-    ```
-    sudo yum update
-    sudo yum groupinstall "Development Tools"
-    sudo yum install qt5-devel
-    ```
-- Arch Linux
+
+- Arch
+
     ```
     sudo pacman -Syu
-    sudo pacman -S base-devel
-    sudo pacman -S qt5-base
+    sudo pacman -S qt6-base qt6-webengine
+    qmake -v
     ```
+
+- Fedora
+
+    ```
+    sudo dnf update
+    sudo dnf install qt6-qtbase-devel qt6-qtwebengine-devel
+    qmake -v
+    ```
+
+- CentOS/RHEL
+
+    ```
+    sudo yum install epel-release
+    sudo yum update
+    sudo yum install qt6-qtbase-devel qt6-qtwebengine-devel
+    qmake -v
+    ```
+
 - openSUSE
+
     ```
     sudo zypper update
-    sudo zypper install -t pattern devel_basis
-    sudo zypper install libqt5-qtbase-devel
+    sudo zypper install libQt6WebEngineWidgets5 libQt6WebEngineCore5-devel
+    qmake -v
     ```
 
 ## Installation

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,12 +5,13 @@ add_subdirectory(Util)
 
 add_executable(QuickTurns main.cpp)
 
-find_package(Qt5 COMPONENTS Core Gui Widgets)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
 
 target_link_libraries(QuickTurns PRIVATE
-    Qt::Core
-    Qt::Gui
-    Qt::Widgets
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets
     ReaderView
     MainView
     ArchiveExtractor

--- a/src/MainView/CMakeLists.txt
+++ b/src/MainView/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(MainView MainView.cpp)
 target_include_directories(MainView PUBLIC include)
 
-find_package(Qt5 COMPONENTS Widgets)
-target_link_libraries(MainView PRIVATE ReaderView Qt::Widgets)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+
+target_link_libraries(MainView PRIVATE ReaderView Qt${QT_VERSION_MAJOR}::Widgets)

--- a/src/ReaderView/CMakeLists.txt
+++ b/src/ReaderView/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(ReaderView ReaderView.cpp)
 target_include_directories(ReaderView PUBLIC include)
 
-find_package(Qt5 COMPONENTS Widgets)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 
-target_link_libraries(ReaderView PRIVATE Qt::Widgets)
+target_link_libraries(ReaderView PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,6 @@
     "builtin-baseline": "20759c873e6b1ae1968e86d42ba70cf2bde0f7a4",
     "dependencies": [
         "gtest",
-        "qt5-base",
         "libzippp",
         "openssl"
     ]


### PR DESCRIPTION
Building Qt webengine is problematic using vcpkg, so one option would be to move Qt installation out of vcpkg.

With this change Qt installation will become requirement, vcpkg will handle other libraries